### PR TITLE
Add .NET 8 API backend and React SPA frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# ManualMaster 2
+
+This repository now provides a .NET 8 Web API and a modern React front end for managing equipment manuals.
+
+## Projects
+
+- `backend/ManualMaster.Api` – ASP.NET Core Web API exposing manual management endpoints backed by SQLite/EF Core.
+- `frontend-react` – Vite powered React SPA that consumes the API.
+- `app.py` and legacy folders – previous Streamlit and prototype clients are retained for reference but superseded by the new stack.
+
+Refer to the `README.md` files inside each project for setup and usage instructions.

--- a/backend/ManualMaster.Api/Controllers/ManualsController.cs
+++ b/backend/ManualMaster.Api/Controllers/ManualsController.cs
@@ -1,0 +1,215 @@
+using System.Text;
+using ManualMaster.Api.Data;
+using ManualMaster.Api.Dtos;
+using ManualMaster.Api.Extensions;
+using ManualMaster.Api.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace ManualMaster.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ManualsController : ControllerBase
+{
+    private readonly ManualContext _context;
+
+    public ManualsController(ManualContext context)
+    {
+        _context = context;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<ManualSummaryDto>>> GetManuals(
+        [FromQuery] string? category,
+        [FromQuery] string? search)
+    {
+        IQueryable<Manual> query = _context.Manuals.AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(category))
+        {
+            var normalizedCategory = category.Trim();
+            query = query.Where(m => EF.Functions.Like(m.Category, normalizedCategory));
+        }
+
+        var manuals = await query.ToListAsync();
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var normalizedSearch = search.Trim();
+            manuals = manuals
+                .Where(m =>
+                    m.Title.Contains(normalizedSearch, StringComparison.OrdinalIgnoreCase) ||
+                    m.Category.Contains(normalizedSearch, StringComparison.OrdinalIgnoreCase) ||
+                    m.Tags.Any(tag => tag.Contains(normalizedSearch, StringComparison.OrdinalIgnoreCase)) ||
+                    m.Content.Contains(normalizedSearch, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        var results = manuals
+            .OrderByDescending(m => m.UploadDate)
+            .Select(m => m.ToSummaryDto())
+            .ToList();
+
+        return Ok(results);
+    }
+
+    [HttpGet("categories")]
+    public async Task<ActionResult<IEnumerable<string>>> GetCategories()
+    {
+        var dbCategories = await _context.Manuals
+            .Select(m => m.Category)
+            .Distinct()
+            .ToListAsync();
+
+        var categories = ManualDefaults.Categories
+            .Union(dbCategories, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(c => c)
+            .ToList();
+
+        return Ok(categories);
+    }
+
+    [HttpGet("{id:int}")]
+    public async Task<ActionResult<ManualDto>> GetManual(int id)
+    {
+        var manual = await _context.Manuals.AsNoTracking().FirstOrDefaultAsync(m => m.Id == id);
+
+        if (manual is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(manual.ToDto());
+    }
+
+    [HttpGet("{id:int}/download")]
+    public async Task<IActionResult> DownloadManual(int id)
+    {
+        var manual = await _context.Manuals.AsNoTracking().FirstOrDefaultAsync(m => m.Id == id);
+
+        if (manual is null || manual.FileData is null)
+        {
+            return NotFound();
+        }
+
+        var fileName = string.IsNullOrWhiteSpace(manual.FileName) ? $"manual-{id}.bin" : manual.FileName;
+        var fileType = string.IsNullOrWhiteSpace(manual.FileType) ? "application/octet-stream" : manual.FileType;
+
+        return File(manual.FileData, fileType, fileName);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<ManualDto>> CreateManual([FromBody] ManualCreateRequest request)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        var manual = new Manual
+        {
+            Title = request.Title.Trim(),
+            Category = request.Category.Trim(),
+            Tags = request.Tags
+                .Select(tag => tag.Trim())
+                .Where(tag => !string.IsNullOrWhiteSpace(tag))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            Content = request.Content,
+            FileName = request.FileName,
+            FileType = request.FileType,
+            SourceUrl = request.SourceUrl,
+            SearchQuery = request.SearchQuery,
+            UploadDate = DateTime.UtcNow
+        };
+
+        if (!string.IsNullOrWhiteSpace(request.FileDataBase64))
+        {
+            try
+            {
+                manual.FileData = Convert.FromBase64String(request.FileDataBase64);
+                manual.Size = manual.FileData.Length;
+            }
+            catch (FormatException)
+            {
+                return BadRequest("Uploaded file could not be decoded from base64.");
+            }
+        }
+        else
+        {
+            manual.Size = Encoding.UTF8.GetByteCount(manual.Content);
+        }
+
+        _context.Manuals.Add(manual);
+        await _context.SaveChangesAsync();
+
+        return CreatedAtAction(nameof(GetManual), new { id = manual.Id }, manual.ToDto());
+    }
+
+    [HttpPut("{id:int}")]
+    public async Task<ActionResult<ManualDto>> UpdateManual(int id, [FromBody] ManualUpdateRequest request)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        var manual = await _context.Manuals.FirstOrDefaultAsync(m => m.Id == id);
+        if (manual is null)
+        {
+            return NotFound();
+        }
+
+        manual.Title = request.Title.Trim();
+        manual.Category = request.Category.Trim();
+        manual.Tags = request.Tags
+            .Select(tag => tag.Trim())
+            .Where(tag => !string.IsNullOrWhiteSpace(tag))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        manual.Content = request.Content;
+        manual.FileName = request.FileName;
+        manual.FileType = request.FileType;
+        manual.SourceUrl = request.SourceUrl;
+        manual.SearchQuery = request.SearchQuery;
+        manual.UploadDate = DateTime.UtcNow;
+
+        if (!string.IsNullOrWhiteSpace(request.FileDataBase64))
+        {
+            try
+            {
+                manual.FileData = Convert.FromBase64String(request.FileDataBase64);
+                manual.Size = manual.FileData.Length;
+            }
+            catch (FormatException)
+            {
+                return BadRequest("Uploaded file could not be decoded from base64.");
+            }
+        }
+        else
+        {
+            manual.FileData = null;
+            manual.Size = Encoding.UTF8.GetByteCount(manual.Content);
+        }
+
+        await _context.SaveChangesAsync();
+
+        return Ok(manual.ToDto());
+    }
+
+    [HttpDelete("{id:int}")]
+    public async Task<IActionResult> DeleteManual(int id)
+    {
+        var manual = await _context.Manuals.FirstOrDefaultAsync(m => m.Id == id);
+        if (manual is null)
+        {
+            return NotFound();
+        }
+
+        _context.Manuals.Remove(manual);
+        await _context.SaveChangesAsync();
+
+        return NoContent();
+    }
+}

--- a/backend/ManualMaster.Api/Data/ManualContext.cs
+++ b/backend/ManualMaster.Api/Data/ManualContext.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+using ManualMaster.Api.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace ManualMaster.Api.Data;
+
+public class ManualContext : DbContext
+{
+    public ManualContext(DbContextOptions<ManualContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Manual> Manuals => Set<Manual>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        var tagsConverter = new ValueConverter<List<string>, string>(
+            v => JsonSerializer.Serialize(v ?? new List<string>(), (JsonSerializerOptions?)null),
+            v => string.IsNullOrWhiteSpace(v)
+                ? new List<string>()
+                : JsonSerializer.Deserialize<List<string>>(v, (JsonSerializerOptions?)null) ?? new List<string>()
+        );
+
+        modelBuilder.Entity<Manual>(entity =>
+        {
+            entity.Property(e => e.Tags)
+                .HasConversion(tagsConverter)
+                .HasColumnType("TEXT");
+
+            entity.Property(e => e.UploadDate)
+                .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+            entity.Property(e => e.Content)
+                .HasColumnType("TEXT");
+        });
+    }
+}

--- a/backend/ManualMaster.Api/Data/ManualDefaults.cs
+++ b/backend/ManualMaster.Api/Data/ManualDefaults.cs
@@ -1,0 +1,18 @@
+namespace ManualMaster.Api.Data;
+
+public static class ManualDefaults
+{
+    public static readonly IReadOnlyList<string> Categories = new List<string>
+    {
+        "Appliance",
+        "Car",
+        "Electronics",
+        "Home & Garden",
+        "HVAC",
+        "Kitchen",
+        "Plumbing",
+        "Tech",
+        "Tools",
+        "Other"
+    };
+}

--- a/backend/ManualMaster.Api/Data/ManualSeeder.cs
+++ b/backend/ManualMaster.Api/Data/ManualSeeder.cs
@@ -1,0 +1,40 @@
+using ManualMaster.Api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace ManualMaster.Api.Data;
+
+public class ManualSeeder
+{
+    private readonly ManualContext _context;
+
+    public ManualSeeder(ManualContext context)
+    {
+        _context = context;
+    }
+
+    public async Task SeedAsync(CancellationToken cancellationToken = default)
+    {
+        if (await _context.Manuals.AnyAsync(cancellationToken))
+        {
+            return;
+        }
+
+        var demoManual = new Manual
+        {
+            Title = "Getting Started Washer Manual",
+            Category = "Appliance",
+            Tags = new List<string> { "washer", "laundry", "quick-start" },
+            Content = "Welcome to ManualMaster! This sample manual shows how text content can be stored without an uploaded PDF.\n\nSteps:\n1. Install the appliance.\n2. Connect hoses.\n3. Run initial rinse cycle.",
+            FileType = null,
+            FileName = null,
+            FileData = null,
+            Size = 0,
+            SourceUrl = null,
+            SearchQuery = null,
+            UploadDate = DateTime.UtcNow
+        };
+
+        _context.Manuals.Add(demoManual);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/backend/ManualMaster.Api/Dtos/ManualCreateRequest.cs
+++ b/backend/ManualMaster.Api/Dtos/ManualCreateRequest.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ManualMaster.Api.Dtos;
+
+public class ManualCreateRequest
+{
+    [Required]
+    [MaxLength(255)]
+    public string Title { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(100)]
+    public string Category { get; set; } = "Other";
+
+    public List<string> Tags { get; set; } = new();
+
+    [Required]
+    public string Content { get; set; } = string.Empty;
+
+    public string? FileName { get; set; }
+
+    public string? FileType { get; set; }
+
+    public string? FileDataBase64 { get; set; }
+
+    public string? SourceUrl { get; set; }
+
+    public string? SearchQuery { get; set; }
+}

--- a/backend/ManualMaster.Api/Dtos/ManualDto.cs
+++ b/backend/ManualMaster.Api/Dtos/ManualDto.cs
@@ -1,0 +1,16 @@
+namespace ManualMaster.Api.Dtos;
+
+public record ManualDto(
+    int Id,
+    string Title,
+    string Category,
+    IReadOnlyCollection<string> Tags,
+    string Content,
+    string? FileName,
+    string? FileType,
+    int Size,
+    DateTime UploadDate,
+    string? SourceUrl,
+    string? SearchQuery,
+    string? FileDataBase64
+);

--- a/backend/ManualMaster.Api/Dtos/ManualSummaryDto.cs
+++ b/backend/ManualMaster.Api/Dtos/ManualSummaryDto.cs
@@ -1,0 +1,10 @@
+namespace ManualMaster.Api.Dtos;
+
+public record ManualSummaryDto(
+    int Id,
+    string Title,
+    string Category,
+    IReadOnlyCollection<string> Tags,
+    DateTime UploadDate,
+    int Size
+);

--- a/backend/ManualMaster.Api/Dtos/ManualUpdateRequest.cs
+++ b/backend/ManualMaster.Api/Dtos/ManualUpdateRequest.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ManualMaster.Api.Dtos;
+
+public class ManualUpdateRequest
+{
+    [Required]
+    [MaxLength(255)]
+    public string Title { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(100)]
+    public string Category { get; set; } = "Other";
+
+    public List<string> Tags { get; set; } = new();
+
+    [Required]
+    public string Content { get; set; } = string.Empty;
+
+    public string? FileName { get; set; }
+
+    public string? FileType { get; set; }
+
+    public string? FileDataBase64 { get; set; }
+
+    public string? SourceUrl { get; set; }
+
+    public string? SearchQuery { get; set; }
+}

--- a/backend/ManualMaster.Api/Extensions/ManualMappingExtensions.cs
+++ b/backend/ManualMaster.Api/Extensions/ManualMappingExtensions.cs
@@ -1,0 +1,33 @@
+using ManualMaster.Api.Dtos;
+using ManualMaster.Api.Models;
+
+namespace ManualMaster.Api.Extensions;
+
+public static class ManualMappingExtensions
+{
+    public static ManualSummaryDto ToSummaryDto(this Manual manual) =>
+        new(
+            manual.Id,
+            manual.Title,
+            manual.Category,
+            manual.Tags.AsReadOnly(),
+            manual.UploadDate,
+            manual.Size
+        );
+
+    public static ManualDto ToDto(this Manual manual) =>
+        new(
+            manual.Id,
+            manual.Title,
+            manual.Category,
+            manual.Tags.AsReadOnly(),
+            manual.Content,
+            manual.FileName,
+            manual.FileType,
+            manual.Size,
+            manual.UploadDate,
+            manual.SourceUrl,
+            manual.SearchQuery,
+            manual.FileData is null ? null : Convert.ToBase64String(manual.FileData)
+        );
+}

--- a/backend/ManualMaster.Api/ManualMaster.Api.csproj
+++ b/backend/ManualMaster.Api/ManualMaster.Api.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+</Project>

--- a/backend/ManualMaster.Api/Models/Manual.cs
+++ b/backend/ManualMaster.Api/Models/Manual.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ManualMaster.Api.Models;
+
+public class Manual
+{
+    public int Id { get; set; }
+
+    [Required]
+    [MaxLength(255)]
+    public string Title { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(100)]
+    public string Category { get; set; } = "Other";
+
+    public List<string> Tags { get; set; } = new();
+
+    [Required]
+    public string Content { get; set; } = string.Empty;
+
+    public byte[]? FileData { get; set; }
+
+    [MaxLength(50)]
+    public string? FileType { get; set; }
+
+    [MaxLength(255)]
+    public string? FileName { get; set; }
+
+    public DateTime UploadDate { get; set; } = DateTime.UtcNow;
+
+    public int Size { get; set; }
+
+    [MaxLength(500)]
+    public string? SourceUrl { get; set; }
+
+    [MaxLength(255)]
+    public string? SearchQuery { get; set; }
+}

--- a/backend/ManualMaster.Api/Program.cs
+++ b/backend/ManualMaster.Api/Program.cs
@@ -1,0 +1,54 @@
+using ManualMaster.Api.Data;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var connectionString = builder.Configuration.GetConnectionString("Manuals")
+    ?? builder.Configuration["MANUALS_CONNECTION"]
+    ?? "Data Source=manuals.db";
+
+builder.Services.AddDbContext<ManualContext>(options =>
+    options.UseSqlite(connectionString));
+
+builder.Services.AddScoped<ManualSeeder>();
+
+builder.Services.AddControllers();
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("default", policy =>
+    {
+        policy
+            .AllowAnyHeader()
+            .AllowAnyMethod()
+            .AllowCredentials()
+            .SetIsOriginAllowed(_ => true);
+    });
+});
+
+var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var context = scope.ServiceProvider.GetRequiredService<ManualContext>();
+    await context.Database.EnsureCreatedAsync();
+
+    var seeder = scope.ServiceProvider.GetRequiredService<ManualSeeder>();
+    await seeder.SeedAsync();
+}
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.UseCors("default");
+app.UseAuthorization();
+app.MapControllers();
+
+app.Run();

--- a/backend/ManualMaster.Api/appsettings.json
+++ b/backend/ManualMaster.Api/appsettings.json
@@ -1,0 +1,11 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "ConnectionStrings": {
+    "Manuals": "Data Source=manuals.db"
+  }
+}

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,27 @@
+# ManualMaster .NET 8 API
+
+This folder contains the ASP.NET Core Web API that powers the ManualMaster application. The service exposes endpoints for managing manuals, uploading optional binary attachments and browsing categories.
+
+## Getting started
+
+1. Install the .NET 8 SDK.
+2. From the `backend/ManualMaster.Api` directory restore packages and run the API:
+
+```bash
+dotnet restore
+dotnet run
+```
+
+The API listens on `https://localhost:5001` / `http://localhost:5000` by default. Update the `ConnectionStrings:Manuals` entry in `appsettings.json` to point at a different SQLite database if needed.
+
+## Available endpoints
+
+- `GET /api/manuals` – list manuals with optional `category` and `search` query parameters.
+- `GET /api/manuals/{id}` – fetch a single manual including content and attachment metadata.
+- `GET /api/manuals/{id}/download` – download the stored binary file if available.
+- `POST /api/manuals` – create a manual. Accepts JSON with fields matching `ManualCreateRequest` (including optional `fileDataBase64`).
+- `PUT /api/manuals/{id}` – update an existing manual.
+- `DELETE /api/manuals/{id}` – remove a manual.
+- `GET /api/manuals/categories` – list categories merged from defaults and existing entries.
+
+Swagger UI is enabled in development builds for quick exploration of the contract.

--- a/frontend-react/.gitignore
+++ b/frontend-react/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.dist
+.DS_Store
+.vite
+coverage
+dist

--- a/frontend-react/README.md
+++ b/frontend-react/README.md
@@ -1,0 +1,30 @@
+# ManualMaster React front end
+
+This directory hosts the Vite + React client for the ManualMaster application. It communicates with the .NET 8 API located under `../backend/ManualMaster.Api`.
+
+## Setup
+
+1. Install Node.js 18 or newer.
+2. Install dependencies:
+
+```bash
+npm install
+```
+
+3. Start the development server:
+
+```bash
+npm run dev
+```
+
+By default the app expects the API to be reachable at `http://localhost:5000/api`. Override this by creating a `.env` file with `VITE_API_BASE_URL`.
+
+## Production build
+
+To create an optimized build run:
+
+```bash
+npm run build
+```
+
+The output will be written to the `dist` folder.

--- a/frontend-react/index.html
+++ b/frontend-react/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ManualMaster</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "manualmaster-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.1",
+    "eslint": "^8.56.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.4",
+    "vite": "^5.1.0"
+  }
+}

--- a/frontend-react/src/App.jsx
+++ b/frontend-react/src/App.jsx
@@ -1,0 +1,133 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useManuals } from './hooks/useManuals.js';
+import ManualList from './components/ManualList.jsx';
+import ManualDetail from './components/ManualDetail.jsx';
+import ManualForm from './components/ManualForm.jsx';
+import SearchFilters from './components/SearchFilters.jsx';
+
+function App() {
+  const {
+    manuals,
+    categories,
+    isLoading,
+    error,
+    refresh,
+    createManual,
+    deleteManual,
+    getManual
+  } = useManuals();
+
+  const [selectedManualId, setSelectedManualId] = useState(null);
+  const [selectedManual, setSelectedManual] = useState(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState('All');
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    let ignore = false;
+
+    const fetchManual = async () => {
+      if (selectedManualId == null) {
+        setSelectedManual(null);
+        return;
+      }
+
+      const manual = await getManual(selectedManualId);
+      if (!ignore) {
+        setSelectedManual(manual);
+      }
+    };
+
+    fetchManual();
+
+    return () => {
+      ignore = true;
+    };
+  }, [selectedManualId, getManual]);
+
+  const filteredManuals = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+    return manuals.filter((manual) => {
+      const matchesCategory =
+        selectedCategory === 'All' || manual.category.toLowerCase() === selectedCategory.toLowerCase();
+
+      if (!normalizedSearch) {
+        return matchesCategory;
+      }
+
+      const combinedText = [
+        manual.title,
+        manual.category,
+        manual.tags.join(' ')
+      ]
+        .join(' ')
+        .toLowerCase();
+
+      return matchesCategory && combinedText.includes(normalizedSearch);
+    });
+  }, [manuals, searchTerm, selectedCategory]);
+
+  const handleManualCreated = async (payload) => {
+    const created = await createManual(payload);
+    if (created) {
+      setSelectedManualId(created.id);
+      setSelectedManual(created);
+    }
+  };
+
+  const handleDeleteManual = async (id) => {
+    const removed = await deleteManual(id);
+    if (removed) {
+      setSelectedManualId((current) => (current === id ? null : current));
+      setSelectedManual((current) => (current?.id === id ? null : current));
+    }
+  };
+
+  return (
+    <div className="app-shell">
+      <header>
+        <h1>ManualMaster</h1>
+        <p>Your manuals, modernized with a .NET 8 API and React experience.</p>
+      </header>
+
+      <main>
+        <aside className="sidebar">
+          <SearchFilters
+            searchTerm={searchTerm}
+            onSearchTermChange={setSearchTerm}
+            categories={[{ label: 'All', value: 'All' }, ...categories.map((c) => ({ label: c, value: c }))]}
+            selectedCategory={selectedCategory}
+            onCategoryChange={setSelectedCategory}
+            isLoading={isLoading}
+          />
+
+          <ManualForm
+            onSubmit={handleManualCreated}
+            isBusy={isLoading}
+          />
+
+          {error && <div className="status-banner error">{error}</div>}
+        </aside>
+
+        <section className="content">
+          <ManualList
+            manuals={filteredManuals}
+            onSelectManual={setSelectedManualId}
+            selectedManualId={selectedManualId}
+            isLoading={isLoading}
+          />
+
+          <ManualDetail
+            manual={selectedManual}
+            onDelete={handleDeleteManual}
+          />
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend-react/src/api/client.js
+++ b/frontend-react/src/api/client.js
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const baseURL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:5000/api';
+
+export const api = axios.create({
+  baseURL
+});

--- a/frontend-react/src/components/ManualDetail.jsx
+++ b/frontend-react/src/components/ManualDetail.jsx
@@ -1,0 +1,72 @@
+import PropTypes from 'prop-types';
+import TagList from './TagList.jsx';
+import { downloadBase64File } from '../utils/download.js';
+
+function ManualDetail({ manual, onDelete }) {
+  if (!manual) {
+    return <div className="manual-detail">Select a manual to see the details.</div>;
+  }
+
+  const handleDownload = () => {
+    if (!manual.fileDataBase64) {
+      return;
+    }
+
+    downloadBase64File(manual.fileDataBase64, manual.fileName ?? `manual-${manual.id}.bin`, manual.fileType ?? 'application/octet-stream');
+  };
+
+  return (
+    <article className="manual-detail">
+      <div className="badge">{manual.category}</div>
+      <h2>{manual.title}</h2>
+      <div className="tag-list">
+        <TagList tags={manual.tags} />
+      </div>
+
+      <p>
+        Uploaded {new Date(manual.uploadDate).toLocaleString()} — {manual.size} bytes
+      </p>
+
+      {manual.sourceUrl && (
+        <p>
+          Source: <a href={manual.sourceUrl} target="_blank" rel="noreferrer">{manual.sourceUrl}</a>
+        </p>
+      )}
+
+      <h3>Content</h3>
+      <pre>{manual.content}</pre>
+
+      <div className="button-group">
+        <button type="button" className="secondary" onClick={() => onDelete(manual.id)}>
+          Delete manual
+        </button>
+        <button type="button" className="primary" onClick={handleDownload} disabled={!manual.fileDataBase64}>
+          Download file
+        </button>
+      </div>
+    </article>
+  );
+}
+
+ManualDetail.propTypes = {
+  manual: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    title: PropTypes.string.isRequired,
+    category: PropTypes.string.isRequired,
+    tags: PropTypes.arrayOf(PropTypes.string).isRequired,
+    content: PropTypes.string.isRequired,
+    fileDataBase64: PropTypes.string,
+    fileType: PropTypes.string,
+    fileName: PropTypes.string,
+    uploadDate: PropTypes.string.isRequired,
+    size: PropTypes.number.isRequired,
+    sourceUrl: PropTypes.string
+  }),
+  onDelete: PropTypes.func.isRequired
+};
+
+ManualDetail.defaultProps = {
+  manual: null
+};
+
+export default ManualDetail;

--- a/frontend-react/src/components/ManualForm.jsx
+++ b/frontend-react/src/components/ManualForm.jsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+
+const emptyForm = {
+  title: '',
+  category: 'Other',
+  tags: '',
+  content: '',
+  file: null,
+  sourceUrl: '',
+  searchQuery: ''
+};
+
+function ManualForm({ onSubmit, isBusy }) {
+  const [formState, setFormState] = useState(emptyForm);
+  const [status, setStatus] = useState(null);
+
+  const updateField = (field, value) => {
+    setFormState((previous) => ({ ...previous, [field]: value }));
+  };
+
+  const handleFileChange = (event) => {
+    const file = event.target.files?.[0] ?? null;
+    updateField('file', file);
+  };
+
+  const reset = () => {
+    setFormState(emptyForm);
+    setStatus({ type: 'success', message: 'Manual uploaded successfully.' });
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    const payload = {
+      title: formState.title,
+      category: formState.category,
+      tags: formState.tags
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter(Boolean),
+      content: formState.content,
+      sourceUrl: formState.sourceUrl || null,
+      searchQuery: formState.searchQuery || null,
+      fileName: formState.file?.name ?? null,
+      fileType: formState.file?.type ?? null,
+      fileDataBase64: null
+    };
+
+    if (formState.file) {
+      const buffer = await formState.file.arrayBuffer();
+      const bytes = new Uint8Array(buffer);
+      let binary = '';
+      bytes.forEach((b) => {
+        binary += String.fromCharCode(b);
+      });
+      payload.fileDataBase64 = btoa(binary);
+    }
+
+    const result = await onSubmit(payload);
+
+    if (result) {
+      reset();
+    } else {
+      setStatus({ type: 'error', message: 'Unable to save manual. Please try again.' });
+    }
+  };
+
+  return (
+    <form className="form-section" onSubmit={handleSubmit}>
+      <h2>Add manual</h2>
+      <label htmlFor="manual-title">Title</label>
+      <input
+        id="manual-title"
+        required
+        value={formState.title}
+        onChange={(event) => updateField('title', event.target.value)}
+        placeholder="User manual title"
+      />
+
+      <label htmlFor="manual-category">Category</label>
+      <input
+        id="manual-category"
+        value={formState.category}
+        onChange={(event) => updateField('category', event.target.value)}
+        placeholder="Appliance, Tech, ..."
+      />
+
+      <label htmlFor="manual-tags">Tags</label>
+      <input
+        id="manual-tags"
+        value={formState.tags}
+        onChange={(event) => updateField('tags', event.target.value)}
+        placeholder="Comma separated"
+      />
+
+      <label htmlFor="manual-content">Content</label>
+      <textarea
+        id="manual-content"
+        required
+        rows={6}
+        value={formState.content}
+        onChange={(event) => updateField('content', event.target.value)}
+        placeholder="Paste text from the manual here"
+      />
+
+      <label htmlFor="manual-file">Attach file (optional)</label>
+      <input id="manual-file" type="file" onChange={handleFileChange} />
+
+      <label htmlFor="manual-source">Source URL</label>
+      <input
+        id="manual-source"
+        value={formState.sourceUrl}
+        onChange={(event) => updateField('sourceUrl', event.target.value)}
+        placeholder="https://example.com/manual.pdf"
+      />
+
+      <label htmlFor="manual-search">Search query</label>
+      <input
+        id="manual-search"
+        value={formState.searchQuery}
+        onChange={(event) => updateField('searchQuery', event.target.value)}
+        placeholder="Keywords used to find the manual"
+      />
+
+      <button type="submit" className="primary" disabled={isBusy}>
+        {isBusy ? 'Saving…' : 'Save manual'}
+      </button>
+
+      {status && <div className={`status-banner ${status.type}`}>{status.message}</div>}
+    </form>
+  );
+}
+
+ManualForm.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+  isBusy: PropTypes.bool
+};
+
+ManualForm.defaultProps = {
+  isBusy: false
+};
+
+export default ManualForm;

--- a/frontend-react/src/components/ManualList.jsx
+++ b/frontend-react/src/components/ManualList.jsx
@@ -1,0 +1,55 @@
+import PropTypes from 'prop-types';
+import TagList from './TagList.jsx';
+
+function ManualList({ manuals, onSelectManual, selectedManualId, isLoading }) {
+  if (isLoading && manuals.length === 0) {
+    return <div className="manual-detail">Loading manuals...</div>;
+  }
+
+  if (!isLoading && manuals.length === 0) {
+    return <div className="manual-detail">No manuals found. Try uploading one!</div>;
+  }
+
+  return (
+    <div className="manual-grid">
+      {manuals.map((manual) => (
+        <article
+          key={manual.id}
+          className="manual-card"
+          onClick={() => onSelectManual(manual.id)}
+          role="button"
+        >
+          <div className="badge">{manual.category}</div>
+          <h3>{manual.title}</h3>
+          <div className="tag-list">
+            <TagList tags={manual.tags} />
+          </div>
+          <small>{new Date(manual.uploadDate).toLocaleString()}</small>
+          {selectedManualId === manual.id && <small>Currently viewing</small>}
+        </article>
+      ))}
+    </div>
+  );
+}
+
+ManualList.propTypes = {
+  manuals: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      title: PropTypes.string.isRequired,
+      category: PropTypes.string.isRequired,
+      tags: PropTypes.arrayOf(PropTypes.string).isRequired,
+      uploadDate: PropTypes.string.isRequired
+    })
+  ).isRequired,
+  onSelectManual: PropTypes.func.isRequired,
+  selectedManualId: PropTypes.number,
+  isLoading: PropTypes.bool
+};
+
+ManualList.defaultProps = {
+  selectedManualId: null,
+  isLoading: false
+};
+
+export default ManualList;

--- a/frontend-react/src/components/SearchFilters.jsx
+++ b/frontend-react/src/components/SearchFilters.jsx
@@ -1,0 +1,50 @@
+import PropTypes from 'prop-types';
+
+function SearchFilters({ searchTerm, onSearchTermChange, categories, selectedCategory, onCategoryChange, isLoading }) {
+  return (
+    <section className="form-section">
+      <h2>Search manuals</h2>
+      <label htmlFor="search-query">Search</label>
+      <input
+        id="search-query"
+        value={searchTerm}
+        onChange={(event) => onSearchTermChange(event.target.value)}
+        placeholder="Search by title, category or tags"
+      />
+
+      <label htmlFor="search-category">Category</label>
+      <select
+        id="search-category"
+        value={selectedCategory}
+        onChange={(event) => onCategoryChange(event.target.value)}
+        disabled={isLoading}
+      >
+        {categories.map((category) => (
+          <option key={category.value} value={category.value}>
+            {category.label}
+          </option>
+        ))}
+      </select>
+    </section>
+  );
+}
+
+SearchFilters.propTypes = {
+  searchTerm: PropTypes.string.isRequired,
+  onSearchTermChange: PropTypes.func.isRequired,
+  categories: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired
+    })
+  ).isRequired,
+  selectedCategory: PropTypes.string.isRequired,
+  onCategoryChange: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool
+};
+
+SearchFilters.defaultProps = {
+  isLoading: false
+};
+
+export default SearchFilters;

--- a/frontend-react/src/components/TagList.jsx
+++ b/frontend-react/src/components/TagList.jsx
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+
+function TagList({ tags }) {
+  if (!tags || tags.length === 0) {
+    return <span className="tag">No tags</span>;
+  }
+
+  return tags.map((tag) => (
+    <span key={tag} className="tag">
+      #{tag}
+    </span>
+  ));
+}
+
+TagList.propTypes = {
+  tags: PropTypes.arrayOf(PropTypes.string)
+};
+
+TagList.defaultProps = {
+  tags: []
+};
+
+export default TagList;

--- a/frontend-react/src/hooks/useManuals.js
+++ b/frontend-react/src/hooks/useManuals.js
@@ -1,0 +1,107 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { api } from '../api/client.js';
+
+const toSummary = (manual) => ({
+  id: manual.id,
+  title: manual.title,
+  category: manual.category,
+  tags: manual.tags,
+  uploadDate: manual.uploadDate,
+  size: manual.size
+});
+
+export function useManuals() {
+  const [manuals, setManuals] = useState([]);
+  const [manualDetails, setManualDetails] = useState({});
+  const [categories, setCategories] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const manualDetailsRef = useRef({});
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const [manualResponse, categoryResponse] = await Promise.all([
+        api.get('/manuals'),
+        api.get('/manuals/categories')
+      ]);
+
+      setManuals(manualResponse.data);
+      setCategories(categoryResponse.data);
+    } catch (err) {
+      setError('Failed to load manuals.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const getManual = useCallback(async (id) => {
+    if (manualDetailsRef.current[id]) {
+      return manualDetailsRef.current[id];
+    }
+
+    try {
+      const response = await api.get(`/manuals/${id}`);
+      const manual = response.data;
+      manualDetailsRef.current = { ...manualDetailsRef.current, [id]: manual };
+      setManualDetails(manualDetailsRef.current);
+      return manual;
+    } catch (err) {
+      setError('Failed to load manual details.');
+      return null;
+    }
+  }, []);
+
+  const createManual = useCallback(async (payload) => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await api.post('/manuals', payload);
+      const manual = response.data;
+      manualDetailsRef.current = { ...manualDetailsRef.current, [manual.id]: manual };
+      setManualDetails(manualDetailsRef.current);
+      setManuals((current) => [toSummary(manual), ...current]);
+      return manual;
+    } catch (err) {
+      setError('Failed to create manual.');
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const deleteManual = useCallback(async (id) => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      await api.delete(`/manuals/${id}`);
+      setManuals((current) => current.filter((manual) => manual.id !== id));
+      manualDetailsRef.current = { ...manualDetailsRef.current };
+      delete manualDetailsRef.current[id];
+      setManualDetails(manualDetailsRef.current);
+      return true;
+    } catch (err) {
+      setError('Failed to delete manual.');
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const value = useMemo(() => ({
+    manuals,
+    categories,
+    isLoading,
+    error,
+    refresh,
+    createManual,
+    deleteManual,
+    getManual
+  }), [manuals, categories, isLoading, error, refresh, createManual, deleteManual, getManual]);
+
+  return value;
+}

--- a/frontend-react/src/main.jsx
+++ b/frontend-react/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend-react/src/styles.css
+++ b/frontend-react/src/styles.css
@@ -1,0 +1,223 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #1f2933;
+  background-color: #f5f7fa;
+}
+
+body {
+  margin: 0;
+}
+
+a {
+  color: inherit;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+header {
+  background: linear-gradient(90deg, #4f46e5, #7c3aed);
+  color: white;
+  padding: 1.5rem 2rem;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+main {
+  flex: 1;
+  padding: 2rem;
+  display: grid;
+  grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+  gap: 2rem;
+}
+
+.sidebar {
+  background: white;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  height: fit-content;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.manual-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.manual-card {
+  background: white;
+  border-radius: 16px;
+  padding: 1.25rem;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  cursor: pointer;
+}
+
+.manual-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.16);
+}
+
+.manual-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: #eef2ff;
+  color: #3730a3;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.tag {
+  padding: 0.2rem 0.6rem;
+  background: #f4f5f7;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  color: #425466;
+}
+
+.manual-detail {
+  background: white;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+}
+
+.manual-detail h2 {
+  margin-top: 0;
+}
+
+.manual-detail pre {
+  background: #111827;
+  color: #e5e7eb;
+  padding: 1rem;
+  border-radius: 12px;
+  max-height: 320px;
+  overflow: auto;
+  white-space: pre-wrap;
+}
+
+.button-group {
+  display: flex;
+  gap: 0.75rem;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+button.primary {
+  background: linear-gradient(90deg, #4f46e5, #6366f1);
+  color: white;
+  box-shadow: 0 10px 20px rgba(99, 102, 241, 0.4);
+}
+
+button.secondary {
+  background: #e4e7eb;
+  color: #1f2933;
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid #d2d6dc;
+  background: #f9fafb;
+  font-size: 0.95rem;
+  font-family: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  border-color: #4f46e5;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}
+
+.form-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.status-banner {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  font-weight: 600;
+  color: #1f2933;
+}
+
+.status-banner.success {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.status-banner.error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+@media (max-width: 1024px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+}

--- a/frontend-react/src/utils/download.js
+++ b/frontend-react/src/utils/download.js
@@ -1,0 +1,12 @@
+export function downloadBase64File(base64, filename, mimeType) {
+  if (!base64) {
+    return;
+  }
+
+  const link = document.createElement('a');
+  link.href = `data:${mimeType};base64,${base64}`;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}

--- a/frontend-react/vite.config.js
+++ b/frontend-react/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- add a .NET 8 ASP.NET Core Web API using EF Core + SQLite to manage manuals
- build a Vite-powered React frontend for browsing, uploading, and deleting manuals through the API
- document the new architecture and provide setup instructions for both projects

## Testing
- not run (dotnet and npm CLIs are unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68fd84d94ab88321b95198e97b2ec2cc